### PR TITLE
run CricleCI for ruby 2.3.3, 2.3.7, 2.5.1, 2.6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,22 @@
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
 version: 2
+
+machine:
+  environment:
+    RUBY_VERSIONS: 2.3.3,2.3.7,2.5.1,2.6.1
+
+dependencies:
+  override:
+    - rvm get head
+    - rvm install $RUBY_VERSIONS
+    - rvm $RUBY_VERSIONS --verbose do gem install bundler
+    - rvm $RUBY_VERSIONS --verbose do bundle install
+
+test:
+  override:
+    - rvm $RUBY_VERSIONS --verbose do bundle exec rspec spec
+
 jobs:
   build:
     working_directory: ~/spiketime


### PR DESCRIPTION
we should test this gem for all ruby versions that we are running across our system.